### PR TITLE
Erro nos loopings do método Troco

### DIFF
--- a/Source Code Inspection/src/br/calebe/ticketmachine/core/Troco.java
+++ b/Source Code Inspection/src/br/calebe/ticketmachine/core/Troco.java
@@ -11,35 +11,15 @@ class Troco {
     protected PapelMoeda[] papeisMoeda;
 
     public Troco(int valor) {
-        papeisMoeda = new PapelMoeda[6];
-        int count = 0;
-        while (valor % 100 != 0) {
-            count++;
-        }
-        papeisMoeda[5] = new PapelMoeda(100, count);
-        count = 0;
-        while (valor % 50 != 0) {
-            count++;
-        }
-        papeisMoeda[4] = new PapelMoeda(50, count);
-        count = 0;
-        while (valor % 20 != 0) {
-            count++;
-        }
-        papeisMoeda[3] = new PapelMoeda(20, count);
-        count = 0;
-        while (valor % 10 != 0) {
-            count++;
-        }
-        papeisMoeda[2] = new PapelMoeda(10, count);
-        count = 0;
-        while (valor % 5 != 0) {
-            count++;
-        }
-        papeisMoeda[1] = new PapelMoeda(5, count);
-        count = 0;
-        while (valor % 2 != 0) {
-            count++;
+        papeisMoeda = new PapelMoeda[5];
+        int[] valoresNotas = {100,50,20,10,5,2};
+
+        for (int i = 0; i < valoresNotas.length; i++){
+            int quantidade = valor / valoresNotas[i];
+            if(quantidade > 0){
+                papeisMoeda[i] = new PapelMoeda(valoresNotas[i], quantidade);
+                valor -= quantidade * valoresNotas[i];
+            }
         }
         //papeisMoeda[1] = new PapelMoeda(2, count);
         // issue resolvido no método acima


### PR DESCRIPTION
Alteração do método do contador do Troco, utilizando um array das notas disponíveis, assim, a cada iteração, o valor é reduzido pela quantidade de notas calculadas, evitando loops sem fim.